### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/mrmime.opam
+++ b/mrmime.opam
@@ -16,7 +16,7 @@ run-test: ["dune" "runtest" "-p" name "-j" jobs]
 
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {build}
+  "dune"
   "uutf"
   "ke" {>= "0.4"}
   "ptime"


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.