### PR TITLE
Fix unstrctrd

### DIFF
--- a/lib/field.ml
+++ b/lib/field.ml
@@ -104,5 +104,5 @@ module Encoder = struct
   let field ppf field =
     let Field (field_name, w, v) = field in
     let e = encoder w in
-    eval ppf [ !!Field_name.Encoder.field_name; string $ ": "; !!e; new_line ] field_name v
+    eval ppf [ tbox 1; !!Field_name.Encoder.field_name; string $ ":"; spaces 1; !!e; close; new_line; ] field_name v
 end

--- a/lib/unstructured.ml
+++ b/lib/unstructured.ml
@@ -40,10 +40,11 @@ module Encoder = struct
     | `Open (TBox n) -> eval ppf [ tbox n ]
     | `Open BBox -> eval ppf [ bbox ]
     | `Close -> eval ppf [ close ]
-    | `FWS wsp -> let ppf = eval ppf [ new_line ] in string ppf (wsp :> string)
+    | `FWS wsp -> let ppf = eval ppf [ cut; new_line ] in string ppf (wsp :> string)
     | `OBS_NO_WS_CTL chr -> char ppf (chr :> char)
-    | `WSP wsp -> string ppf (wsp :> string)
+    | `WSP wsp -> eval ppf [ spaces (String.length (wsp :> string)) ]
     | `d0 -> char ppf '\000'
+    | `Invalid_char _ -> string ppf "\xEF\xBF\xBD"
     | #uchar as uchar ->
       let output = Stdlib.Buffer.create 4 in
       let encoder = Uutf.encoder `UTF_8 (`Buffer output) in

--- a/mrmime.opam
+++ b/mrmime.opam
@@ -20,7 +20,7 @@ depends: [
   "rresult"
   "fmt"
   "ke"               {>= "0.4"}
-  "unstrctrd"
+  "unstrctrd"        {>= "0.2"}
   "ptime"
   "uutf"
   "rosetta"          {>= "0.3.0"}


### PR DESCRIPTION
This PR wants to fix problem highlighted by @Julow. When the unstructured value is larger than 78 characters, the encoder wants to split it but it forget to add the needed whitespace at the front of the next line.

This PR wants to fix that and wrap any values with `tbox 1 ... close` to ensure the _folding-whitespace_. An upgrade to `unstrctrd.0.2` is needed about tests to use `Unstrctrd.safely_decode`. A test was added to see what happens with a large `Subject`.