### PR TITLE
Fix hd

### DIFF
--- a/lib/hd.ml
+++ b/lib/hd.ml
@@ -31,7 +31,7 @@ let parser g =
   let open Angstrom in
   let crlf = char '\r' *> char '\n' in
       (with_location (field g) >>| fun v -> `Field v)
-  <|> (crlf *> crlf *> return `End)
+  <|> (crlf *> return `End)
 
 let decoder ?(p= G.empty) buffer =
   { q= Q.from buffer

--- a/lib/hd.ml
+++ b/lib/hd.ml
@@ -65,8 +65,10 @@ let rec decode : decoder -> decode =
   | Angstrom.Unbuffered.Done (committed, `End) ->
     Q.N.shift_exn decoder.q committed ;
     Q.compress decoder.q ;
-    let[@warning "-8"] [ x ] = Q.N.peek decoder.q in
-    `End (Bigstringaf.to_string x)
+    ( match Q.N.peek decoder.q with
+      | [ x ] -> `End (Bigstringaf.to_string x)
+      | [] -> `End ""
+      | _ -> assert false )
   | Angstrom.Unbuffered.Done (committed, `Field v) ->
     Q.N.shift_exn decoder.q committed ;
     decoder.s <- Angstrom.Unbuffered.parse (parser decoder.p) ;

--- a/test/dune
+++ b/test/dune
@@ -33,6 +33,11 @@
  (modules test_mail)
  (libraries alcotest ptime.clock.os mrmime))
 
+(executable
+ (name test_hd)
+ (modules test_hd)
+ (libraries alcotest mrmime))
+
 (alias
  (name runtest)
  (deps (:rfc2045 rfc2045.exe))
@@ -67,3 +72,9 @@
  (name runtest)
  (deps (:mail test_mail.exe))
  (action (run %{mail} --color=always)))
+
+(alias
+ (name runtest)
+ (deps (:hd test_hd.exe))
+ (action (run %{hd} --color=always)))
+

--- a/test/test_hd.ml
+++ b/test/test_hd.ml
@@ -1,0 +1,98 @@
+open Mrmime
+
+let p =
+  let unstructured = Field.(Witness Unstructured) in
+  let open Field_name in
+  Map.empty
+  |> Map.add date unstructured
+  |> Map.add from unstructured
+  |> Map.add sender unstructured
+  |> Map.add reply_to unstructured
+  |> Map.add (v "To") unstructured
+  |> Map.add cc unstructured
+  |> Map.add bcc unstructured
+  |> Map.add subject unstructured
+  |> Map.add message_id unstructured
+  |> Map.add comments unstructured
+  |> Map.add content_type unstructured
+  |> Map.add content_encoding unstructured
+
+let test_000 =
+{|Date:     26 Aug 76 14:29 EDT
+From:     Jones@Registry.Org
+Bcc:
+
+|}
+
+module Map = Map.Make(Field_name)
+
+let to_unstrctrd (unstructured : Unstructured.t) =
+  let fold acc = function
+    | #Unstrctrd.elt as elt -> elt :: acc
+    | _ -> acc in
+  List.fold_left fold [] unstructured
+  |> List.rev |> Unstrctrd.of_list |> Rresult.R.get_ok
+
+let add k v m =
+  try let vs = Map.find k m in Map.add k (v :: vs) m
+  with Not_found -> Map.add k [ v ] m
+
+let parse str =
+  let tmp = Bigstringaf.create 0x1000 in
+  let pos = ref 0 in
+  let decoder = Hd.decoder ~p tmp in
+  let rec go acc = match Hd.decode decoder with
+    | `End prelude ->
+      Alcotest.(check string) "prelude" prelude "" ; acc
+    | `Field field ->
+      let Field.Field (field_name, w, v) = Location.prj field in
+      ( match w with
+        | Field.Unstructured ->
+          let v = Unstrctrd.(to_utf_8_string (fold_fws (to_unstrctrd v))) in
+          go (add field_name v acc)
+        | _ -> assert false )
+    | `Malformed err -> Alcotest.failf "Hd.decode: %s" err
+    | `Await ->
+      let len = min (String.length str - !pos) 0x100 in
+      match Hd.src decoder str !pos len with
+      | Ok () -> pos := !pos + len ; go acc
+      | Error (`Msg err) -> Alcotest.failf "Hd.src: %s" err in
+  go Map.empty
+
+let test_000 =
+  Alcotest.test_case "header-000" `Quick @@ fun () ->
+  let fields = parse test_000 in
+  Alcotest.(check (list string)) "Date" (Map.find Field_name.date fields)
+    [ "     26 Aug 76 14:29 EDT" ] ;
+  Alcotest.(check (list string)) "From" (Map.find Field_name.from fields)
+    [ "     Jones@Registry.Org" ] ;
+  Alcotest.(check (list string)) "Bcc" (Map.find Field_name.bcc fields)
+    [ "" ]
+
+let test_001 =
+{|From  : John Doe <jdoe@machine(comment).  example>
+To    : Mary Smith
+  
+          <mary@example.net>
+Subject     : Saying Hello
+Date  : Fri, 21 Nov 1997 09(comment):   55  :  06 -0600
+Message-ID  : <1234   @   local(blah)  .machine .example>
+
+|}
+
+let test_001 =
+  Alcotest.test_case "header-000" `Quick @@ fun () ->
+  let fields = parse test_001 in
+  Alcotest.(check (list string)) "From" (Map.find Field_name.from fields)
+    [ " John Doe <jdoe@machine(comment).  example>" ] ;
+  Alcotest.(check (list string)) "To" (Map.find (Field_name.v "To") fields)
+    [ " Mary Smith  <mary@example.net>" ] ;
+  Alcotest.(check (list string)) "Subhect" (Map.find Field_name.subject fields)
+    [ " Saying Hello" ] ;
+  Alcotest.(check (list string)) "Date" (Map.find Field_name.date fields)
+    [ " Fri, 21 Nov 1997 09(comment):   55  :  06 -0600" ] ;
+  Alcotest.(check (list string)) "Message-ID" (Map.find Field_name.message_id fields)
+    [ " <1234   @   local(blah)  .machine .example>" ]
+
+let () =
+  Alcotest.run "hd" [ ("header", [ test_000; test_001 ]) ]

--- a/test/test_mail.ml
+++ b/test/test_mail.ml
@@ -119,7 +119,6 @@ let test1 () =
 
 let subject = "Something larger than 80 columns to see where prettym split contents.\
                A large Subject should be split!"
-let () = Fmt.epr "<<< %S\n%!" subject
 
 let example2 =
   let open Mrmime in


### PR DESCRIPTION
`Hd` is a sub-module which is used to parse only the header. The separation/delimiter of the header is not a double CRLF but only one with nothing between its and the previous CRLF eaten by `Unstrctrd` module. I should add a test about that.