### PR TITLE
Fix fuzzer with the new version of prettym

### DIFF
--- a/lib/content_type.ml
+++ b/lib/content_type.ml
@@ -612,13 +612,15 @@ module Encoder = struct
     | `Iana_token v -> string ppf v
     | `X_token v -> using (fun v -> "X-" ^ v) string ppf v
 
+  let cut : type a. unit -> (a, a) order = fun () -> break ~indent:1 ~len:0
+
   let value =
     using
       (function `Token x -> `Atom x | `String x -> `String x)
       Mailbox.Encoder.word
 
   let parameter ppf (key, v) =
-    eval ppf [ box; !!string; cut; char $ '='; cut; !!value; close ] key v
+    eval ppf [ box; !!string; cut (); char $ '='; cut (); !!value; close ] key v
 
   let parameters ppf parameters =
     let sep ppf () = eval ppf [ char $ ';'; fws ] in
@@ -628,13 +630,13 @@ module Encoder = struct
     match t.parameters with
     | [] ->
         eval ppf
-          [ bbox; !!ty; cut; char $ '/'; cut; !!subty; close ]
+          [ bbox; !!ty; cut (); char $ '/'; cut (); !!subty; close ]
           t.ty t.subty
     | _ ->
         eval ppf
           [
-            bbox; !!ty; cut; char $ '/'; cut; !!subty; cut; char $ ';'; fws;
-            !!parameters; close;
+            bbox; !!ty; cut (); char $ '/'; cut (); !!subty; cut (); char $ ';';
+            fws; !!parameters; close;
           ]
           t.ty t.subty t.parameters
 end

--- a/mrmime.opam
+++ b/mrmime.opam
@@ -36,4 +36,5 @@ depends: [
   "hxd"              {with-test}
   "alcotest"         {with-test}
   "jsonm"            {with-test}
+  "crowbar"          {with-test}
 ]


### PR DESCRIPTION
The semantic of `cut` with `prettym.0.0.1` was updated. So we fix that to be sure that fuzzers work.