### PR TITLE
Unlock the arbitrary limit on the internal buffer used by hd

### DIFF
--- a/lib/hd.mli
+++ b/lib/hd.mli
@@ -23,8 +23,8 @@ type decode =
   | `End of string
   | `Malformed of string ]
 
-val decoder : ?p:Field.witness Field_name.Map.t -> Bigstringaf.t -> decoder
-(** [decoder ?p buf] returns a decoder with a set of field-name binded
+val decoder : Field.witness Field_name.Map.t -> decoder
+(** [decoder parsers] returns a decoder with a set of field-name binded
    with expected kind of value. When the decoder will decode value of
    a given field-name, it will try to extract expected value describe by
    the given {!Field.witness} or it returns a {!Unstructured.t}. *)
@@ -38,7 +38,7 @@ val decode : decoder -> decode
        what the user gaves which is not the part of the header.}
     {- [`Malformed err] we we reach an error while decoding.}} *)
 
-val src : decoder -> string -> int -> int -> (unit, [> Rresult.R.msg ]) result
+val src : decoder -> string -> int -> int -> unit
 (** [src decoder src off len] gives more input to [decoder]. The function
     can fail when given input is bigger than internal buffer of [decoder]
     (see {!decoder}). *)


### PR DESCRIPTION
This PR update the interface, we should add some comments to explain what is going on internally but the behavior of `hd` is better with this - it does not fails for any inputs.