### PR TITLE
Modifying Mail.t type for simplification

### DIFF
--- a/lib/mail.mli
+++ b/lib/mail.mli
@@ -14,12 +14,10 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-type 'a elt = { header : Header.t; body : 'a }
-
 type 'a t =
-  | Leaf of 'a elt
-  | Multipart of 'a t option list elt
-  | Message of 'a t elt
+  | Leaf of 'a
+  | Multipart of (Header.t * 'a t option) list
+  | Message of Header.t * 'a t
 
 val heavy_octet : string option -> Header.t -> string Angstrom.t
 (** {i Heavy} parser of a body - it will stores bodies into [string]. *)

--- a/test/test_mail.ml
+++ b/test/test_mail.ml
@@ -277,8 +277,7 @@ let contents =
 let test3 () =
   Alcotest.test_case "quoted-printable contents" `Quick @@ fun () ->
   match Angstrom.parse_string ~consume:Prefix Mrmime.Mail.mail example3 with
-  | Ok (_, Leaf { Mrmime.Mail.body; _ }) ->
-      Alcotest.(check string) "contents" body contents
+  | Ok (_, Leaf body) -> Alcotest.(check string) "contents" body contents
   | Ok _ -> Fmt.invalid_arg "Invalid structure of the email"
   | Error _ -> Fmt.invalid_arg "Invalid email"
 
@@ -290,7 +289,7 @@ Hello World!
 let test4 () =
   Alcotest.test_case "7-bit contents" `Quick @@ fun () ->
   match Angstrom.parse_string ~consume:Prefix Mrmime.Mail.mail example4 with
-  | Ok (_, Leaf { Mrmime.Mail.body; _ }) ->
+  | Ok (_, Leaf body) ->
       Alcotest.(check string) "contents" body "Hello World!\r\n"
   | Ok _ -> Fmt.invalid_arg "Invalid structure of the email"
   | Error _ -> Fmt.invalid_arg "Invalid email"

--- a/test/test_stream.ml
+++ b/test/test_stream.ml
@@ -59,10 +59,15 @@ let parse ~emitters =
         `Continue
 
 let rec map f = function
-  | Mail.Leaf { header; body } -> Mail.Leaf { header; body = f body }
-  | Multipart { header; body } ->
-      Multipart { header; body = List.map (Option.map (map f)) body }
-  | Message { header; body } -> Message { header; body = map f body }
+  | Mail.Leaf body -> Mail.Leaf (f body)
+  | Multipart parts ->
+      Multipart
+        (List.map
+           (function
+             | header, None -> (header, None)
+             | header, Some body -> (header, Some (map f body)))
+           parts)
+  | Message (header, body) -> Message (header, map f body)
 
 open Lwt.Infix
 


### PR DESCRIPTION
This PR simplifies the type ```Mail.t``` to avoid duplicating headers during parsing.

The type changes from
```ocaml
type 'a elt = { header : Header.t; body : 'a }

type 'a t =
  | Leaf of 'a elt
  | Multipart of 'a t option list elt
  | Message of 'a t elt
```
to :
```ocaml
type 'a t =
  | Leaf of 'a
  | Multipart of (Header.t * 'a t option) list
  | Message of Header.t * 'a t
```

@dinosaure  I broke ```test3``` in ```test_mail.ml```, but I am not sure why. Can you check it, please ?