### PR TITLE
Fix bug in b64.parser related to flushing

### DIFF
--- a/lib/b64.ml
+++ b/lib/b64.ml
@@ -102,7 +102,7 @@ let rec parser ~write_data dec =
       peek_char >>= function
       | None ->
           Base64_rfc2045.src dec Bytes.empty 0 0;
-          commit
+          commit *> parser ~write_data dec
       | Some _ ->
           available >>= fun len ->
           Unsafe.take len Bigstringaf.substring >>= fun str ->


### PR DESCRIPTION
As indicated in this [issue](https://github.com/mirage/mrmime/issues/75), the base64 decoding would ditch the last byte of it's output.
It was due to the code not calling back the parser one last time after all the input was digested.
By forcing this call, Base64_rfc2045 is able to properly flush the last bits if information stored, which would be lost otherwise.