### PR TITLE
Clarify the semantic about the underlying quoted-printable encoder

### DIFF
--- a/lib/mt.mli
+++ b/lib/mt.mli
@@ -28,7 +28,22 @@ val part : ?encoding:bool -> ?header:Header.t -> buffer stream -> part
 (** [part ?encoding ?header stream] makes a new part from a body stream [stream],
    with the given [header] (default to {!Header.empty}). If [header] contains
    a [Content-Transfer-Encoding] and [encoding = true] (default), the stream will
-   be {b encoded} to the given encoding. Otherwise, the stream is not transencoded. *)
+   be {b encoded} to the given encoding. Otherwise, the stream is not transencoded.
+
+   The underlying behavior of the encoding depends on what the user choose:
+   - For a [base64] encoding, the stream is encoded as is and the resulted
+     stream emits the body line-per-line;
+   - For a [raw] encoding, the stream is added as is and should respect the
+     line-per-line emission;
+   - For a [quoted-printable], a chunk of the given stream is considered as
+     a line regardless the newline convention of the operating system
+     (and the encoder put a line-break according to the RFC 2045).
+
+   Despite the [base64] encoding which can safely be used independantly of
+   the behavior of the given stream, [7bit]/[8bit] and [quoted-printable] expect
+   a specific stream line-per-line. [7bit]/[8bit] should include the [CRLF]
+   newline per emission and the [quoted-printable] considers a emitted chunk
+   as a line (without the newline character). *)
 
 val multipart :
   ?g:'g ->

--- a/test/isomorphism.t
+++ b/test/isomorphism.t
@@ -5,7 +5,6 @@ Test isomorphism on contents
   $ ./test_generate.exe $SEED 0 > part-0
   $ diff stdout-0 part-0
   $ ./test_generate.exe $SEED 1 > part-1
-  $ printf "\n" >> part-1
   $ diff stdout-1 part-1
   $ ./test_generate.exe $SEED 2 > part-2
   $ diff stdout-2 part-2

--- a/test/test_generate.ml
+++ b/test/test_generate.ml
@@ -24,6 +24,17 @@ let generate_any random =
 let generate_any_bytes len max = generate_any random_bytes len max
 let generate_any_7bits len max = generate_any random_7bits len max
 
+let generate_any_bytes_with_newline len max =
+  let g = generate_any random_bytes len max in
+  fun () ->
+    match g () with
+    | Some (str, off, len) ->
+        let buf' = Bytes.create (len + 1) in
+        Bytes.blit_string str off buf' 0 len;
+        Bytes.set buf' len '\n';
+        Some (Bytes.unsafe_to_string buf', 0, len + 1)
+    | None -> None
+
 open Mrmime
 
 let max = 1_000_000
@@ -66,7 +77,7 @@ let rec drain stream =
 
 let regenerate part =
   let part0 = generate_any_7bits chunk max in
-  let part1 = generate_any_bytes chunk max in
+  let part1 = generate_any_bytes_with_newline chunk max in
   let part2 = generate_any_bytes chunk max in
   match part with
   | 0 -> show part0


### PR DESCRIPTION
This patch is a bit big about implication but I think it's the better way about the quoted-printable encoding. It considers that the given stream which will be encoded with `pecu` considers any chunks of it as a line. It solves one issue about the expected last `\r\n` in the body (whatever the contents of the stream) and precise a more systemic behavior which corresponds to the real use-case of the `quoted-printable` encoding - transmit a text, regardless the newline convention of the host system.

About isomorphism, it changes a bit the test when we must systematically append a newline for any chunks emitted and we still are able to generate a million of emails which can be decoded/encoded safely without any problems.

/cc @lyrm who knows about that.