### PR TITLE
Be able to wrap a multipart email into a part

### DIFF
--- a/lib/mt.ml
+++ b/lib/mt.ml
@@ -109,10 +109,7 @@ type part = { header : Header.t; body : buffer stream }
 type multipart = { header : Header.t; parts : part list }
 
 let part ?(encoding = true) ?(header = Header.empty) stream =
-  let content_type = Header.content_type header in
   let content_encoding = Header.content_encoding header in
-  if not (Content_type.is_discrete content_type) then
-    Fmt.invalid_arg "Content-type MUST be discrete type to make a part";
   let stream =
     if encoding then
       match content_encoding with


### PR DESCRIPTION
Such usage comes from `blaze` when the stream is a multipart email. We should be able to let the user to do what he/she want when we make a part (even a part which possibly contains a multipart email).