### PR TITLE
Don't use RNG to produce the example to be compatible with OCaml 5.00.0

### DIFF
--- a/examples/attachment.ml
+++ b/examples/attachment.ml
@@ -92,7 +92,10 @@ let rng ?g:_ len =
   done;
   Bytes.unsafe_to_string res
 
-let email = Mt.make header Mt.multi (Mt.multipart ~rng [ part0; part1 ])
+let boundary = "foo"
+
+let email =
+  Mt.make header Mt.multi (Mt.multipart ~rng:Mt.rng ~boundary [ part0; part1 ])
 
 let email =
   let stream = Mt.to_stream email in

--- a/examples/test.t
+++ b/examples/test.t
@@ -4,15 +4,15 @@ Simple email with attachment
   From: romain.calascibetta@gmail.com
   Subject: A Simple Email
   Date: Mon, 26 Apr 2021 16:20:50 GMT
-  Content-Type: multipart/mixed; boundary=YlGxbWQC
+  Content-Type: multipart/mixed; boundary=foo
   
-  --YlGxbWQC
+  --foo
   Content-Transfer-Encoding: quoted-printable
   Content-Type: text/plain
   
   Hello=20World!
   
-  --YlGxbWQC
+  --foo
   Content-Disposition: attachement; filename=mrmime.png
   Content-Transfer-Encoding: base64
   Content-Type: image/png
@@ -1093,4 +1093,4 @@ Simple email with attachment
   ZHRoADg1MJ7GNKcAAAAZdEVYdFRodW1iOjpNaW1ldHlwZQBpbWFnZS9wbmc/slZOAAAAF3RFWHRU
   aHVtYjo6TVRpbWUAMTU1NDQ5MjI0MNxNkFcAAAASdEVYdFRodW1iOjpTaXplADQ4NEtCQmZRA9kA
   AAAASUVORK5CYII=
-  --YlGxbWQC--
+  --foo--


### PR DESCRIPTION
An other fix for OCaml 5.00.0: I don't use the RNG to produce my email anymore on my tests.