### PR TITLE
Fix the tests with OCaml 5.2

### DIFF
--- a/test/rfc5322.ml
+++ b/test/rfc5322.ml
@@ -207,13 +207,13 @@ let parse_content_type x (ty, subty, param_count) =
 (* Check that whitespaces are allowed in content type parameter value (PR#72) *)
 let content_type_test =
   let test =
-    {|From: Nathaniel Borenstein <nsb@thumper.bellcore.com>
-      (=?iso-8859-8?b?7eXs+SDv4SDp7Oj08A==?=)
-To: Greg Vaudreuil <gvaudre@NRI.Reston.VA.US>, Ned Freed
-   <ned@innosoft.com>, Keith Moore <moore@cs.utk.edu>
-Subject: Test of new header generator
-MIME-Version: 1.0
-Content-type: text/plain; wpefjjnqwisj231=" q02eifwe0sn  "; weinfw="qwewqe"
+    {|From: Nathaniel Borenstein <nsb@thumper.bellcore.com>|}^"\r"^{|
+      (=?iso-8859-8?b?7eXs+SDv4SDp7Oj08A==?=)|}^"\r"^{|
+To: Greg Vaudreuil <gvaudre@NRI.Reston.VA.US>, Ned Freed|}^"\r"^{|
+   <ned@innosoft.com>, Keith Moore <moore@cs.utk.edu>|}^"\r"^{|
+Subject: Test of new header generator|}^"\r"^{|
+MIME-Version: 1.0|}^"\r"^{|
+Content-type: text/plain; wpefjjnqwisj231=" q02eifwe0sn  "; weinfw="qwewqe"|}^"\r"^{|
 |}
   in
   let ct =

--- a/test/test_hd.ml
+++ b/test/test_hd.ml
@@ -18,10 +18,10 @@ let parsers =
   |> Map.add content_encoding unstructured
 
 let test_000 =
-  {|Date:     26 Aug 76 14:29 EDT
-From:     Jones@Registry.Org
-Bcc:
-
+  {|Date:     26 Aug 76 14:29 EDT|}^"\r"^{|
+From:     Jones@Registry.Org|}^"\r"^{|
+Bcc:|}^"\r"^{|
+|}^"\r"^{|
 |}
 
 module Map = Map.Make (Field_name)
@@ -77,14 +77,14 @@ let test_000 =
   Alcotest.(check (list string)) "Bcc" (Map.find Field_name.bcc fields) [ "" ]
 
 let test_001 =
-  {|From  : John Doe <jdoe@machine(comment).  example>
-To    : Mary Smith
-  
-          <mary@example.net>
-Subject     : Saying Hello
-Date  : Fri, 21 Nov 1997 09(comment):   55  :  06 -0600
-Message-ID  : <1234   @   local(blah)  .machine .example>
-
+  {|From  : John Doe <jdoe@machine(comment).  example>|}^"\r"^{|
+To    : Mary Smith|}^"\r"^{|
+  |}^"\r"^{|
+          <mary@example.net>|}^"\r"^{|
+Subject     : Saying Hello|}^"\r"^{|
+Date  : Fri, 21 Nov 1997 09(comment):   55  :  06 -0600|}^"\r"^{|
+Message-ID  : <1234   @   local(blah)  .machine .example>|}^"\r"^{|
+|}^"\r"^{|
 |}
 
 let test_001 =

--- a/test/test_mail.ml
+++ b/test/test_mail.ml
@@ -249,18 +249,18 @@ let test2 () =
   | Error _ -> Fmt.invalid_arg "Generate unparsable email"
 
 let example3 =
-  {mrmime|From: romain.calascibetta@x25519.net
-To: romain.calascibetta@din.osau.re
-Content-Type: text/plain; charset=utf-8
-Content-Transfer-Encoding: quoted-printable
-
-J'interdis aux marchands de vanter trop leurs marchandises. Car ils se font=
- vite p=C3=A9dagogues et t'enseignent comme but ce qui n'est par essence qu=
-'un moyen, et te trompant ainsi sur la route =C3=A0 suivre les voil=C3=A0 =
-bient=C3=B4t qui te d=C3=A9gradent, car si leur musique est vulgaire il=
-s te fabriquent pour te la vendre une =C3=A2me vulgaire.            
-   =E2=80=94=E2=80=89Antoine de Saint-Exup=C3=A9ry, Citadelle (1948)
-
+  {mrmime|From: romain.calascibetta@x25519.net|mrmime}^"\r"^{mrmime|
+To: romain.calascibetta@din.osau.re|mrmime}^"\r"^{mrmime|
+Content-Type: text/plain; charset=utf-8|mrmime}^"\r"^{mrmime|
+Content-Transfer-Encoding: quoted-printable|mrmime}^"\r"^{mrmime|
+|mrmime}^"\r"^{mrmime|
+J'interdis aux marchands de vanter trop leurs marchandises. Car ils se font=|mrmime}^"\r"^{mrmime|
+ vite p=C3=A9dagogues et t'enseignent comme but ce qui n'est par essence qu=|mrmime}^"\r"^{mrmime|
+'un moyen, et te trompant ainsi sur la route =C3=A0 suivre les voil=C3=A0 =|mrmime}^"\r"^{mrmime|
+bient=C3=B4t qui te d=C3=A9gradent, car si leur musique est vulgaire il=|mrmime}^"\r"^{mrmime|
+s te fabriquent pour te la vendre une =C3=A2me vulgaire.            |mrmime}^"\r"^{mrmime|
+   =E2=80=94=E2=80=89Antoine de Saint-Exup=C3=A9ry, Citadelle (1948)|mrmime}^"\r"^{mrmime|
+|mrmime}^"\r"^{mrmime|
 |mrmime}
 
 let contents =
@@ -278,9 +278,9 @@ let test3 () =
   | Ok _ -> Fmt.invalid_arg "Invalid structure of the email"
   | Error _ -> Fmt.invalid_arg "Invalid email"
 
-let example4 = {mrmime|Subject: A simple email
-
-Hello World!
+let example4 = {mrmime|Subject: A simple email|mrmime}^"\r"^{mrmime|
+|mrmime}^"\r"^{mrmime|
+Hello World!|mrmime}^"\r"^{mrmime|
 |mrmime}
 
 let test4 () =


### PR DESCRIPTION
Much like https://github.com/mirage/pecu/pull/14 and https://github.com/dinosaure/unstrctrd/pull/17 I feel like this change, while not the prettiest, is reasonable.

Fails with the following error otherwise:
```
#=== ERROR while compiling mrmime.0.6.0 =======================================#
# context              2.2.0~beta2~dev | linux/x86_64 | ocaml-variants.5.2.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.2/.opam-switch/build/mrmime.0.6.0
# command              ~/.opam/5.2/bin/dune runtest -p mrmime -j 1
# exit-code            1
# env-file             ~/.opam/log/mrmime-1652-3fef57.env
# output-file          ~/.opam/log/mrmime-1652-3fef57.out
### output ###
# File "test/dune", line 68, characters 0-100:
# 68 | (rule
# 69 |  (alias runtest)
# 70 |  (deps
# 71 |   (:rfc5322 rfc5322.exe))
# 72 |  (action
# 73 |   (run %{rfc5322} --color=always)))
# (cd _build/default/test && ./rfc5322.exe --color=always)
# Testing `rfc5322'.
# This run has ID `6QJ5XZ4S'.
# 
#   [OK]          header          0   header 0.
#   [OK]          header          1   header 1.
#   [OK]          header          2   header 2.
#   [OK]          header          3   header 3.
#   [OK]          header          4   header 4.
#   [OK]          header          5   header 5.
#   [OK]          header          6   header 6.
#   [OK]          header          7   header 7.
#   [OK]          header          8   header 8.
#   [OK]          header          9   header 9.
#   [OK]          header         10   header 10.
#   [OK]          header         11   header 11.
#   [OK]          header         12   header 12.
#   [OK]          header         13   header 13.
#   [OK]          header         14   header 14.
#   [OK]          header         15   header 15.
#   [OK]          header         16   header 16.
# > [FAIL]        header         17   header - content-type.
# 
# ┌──────────────────────────────────────────────────────────────────────────────┐
# │ [FAIL]        header         17   header - content-type.                     │
# └──────────────────────────────────────────────────────────────────────────────┘
# [failure] Invalid header
#           Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
#           Called from Fmt.failwith in file "src/fmt.ml" (inlined), line 25, characters 19-36
#           Called from Dune__exe__Rfc5322.parse_content_type in file "test/rfc5322.ml", line 197, characters 11-40
#           Called from Dune__exe__Rfc5322.content_type_test.(fun) in file "test/rfc5322.ml", line 223, characters 29-57
#           Called from Alcotest_engine__Core.Make.protect_test.(fun) in file "src/alcotest-engine/core.ml", line 181, characters 17-23
#           Called from Alcotest_engine__Monad.Identity.catch in file "src/alcotest-engine/monad.ml", line 24, characters 31-35
#           
# Logs saved to `~/.opam/5.2/.opam-switch/build/mrmime.0.6.0/_build/default/test/_build/_tests/rfc5322/header.017.output'.
#  ──────────────────────────────────────────────────────────────────────────────
# 
# Full test results in `~/.opam/5.2/.opam-switch/build/mrmime.0.6.0/_build/default/test/_build/_tests/rfc5322'.
# 1 failure! in 0.003s. 18 tests run.
# File "test/dune", line 89, characters 0-96:
# 89 | (rule
# 90 |  (alias runtest)
# 91 |  (deps
# 92 |   (:mail test_mail.exe))
# 93 |  (action
# 94 |   (run %{mail} --color=always)))
# (cd _build/default/test && ./test_mail.exe --color=always)
# Testing `mail'.
# This run has ID `URG21E1Q'.
# 
#   [OK]          example          0   example 0.
#   [OK]          example          1   example 1.
#   [OK]          example          2   large subject.
# > [FAIL]        example          3   quoted-printable contents.
#   [FAIL]        example          4   7-bit contents.
# 
# ┌──────────────────────────────────────────────────────────────────────────────┐
# │ [FAIL]        example          3   quoted-printable contents.                │
# └──────────────────────────────────────────────────────────────────────────────┘
# [invalid] Invalid email
#           Raised at Stdlib.invalid_arg in file "stdlib.ml", line 30, characters 20-45
#           Called from Alcotest_engine__Core.Make.protect_test.(fun) in file "src/alcotest-engine/core.ml", line 181, characters 17-23
#           Called from Alcotest_engine__Monad.Identity.catch in file "src/alcotest-engine/monad.ml", line 24, characters 31-35
#           
# Logs saved to `~/.opam/5.2/.opam-switch/build/mrmime.0.6.0/_build/default/test/_build/_tests/mail/example.003.output'.
#  ──────────────────────────────────────────────────────────────────────────────
# 
# Full test results in `~/.opam/5.2/.opam-switch/build/mrmime.0.6.0/_build/default/test/_build/_tests/mail'.
# 2 failures! in 0.013s. 5 tests run.
# File "test/dune", line 96, characters 0-90:
#  96 | (rule
#  97 |  (alias runtest)
#  98 |  (deps
#  99 |   (:hd test_hd.exe))
# 100 |  (action
# 101 |   (run %{hd} --color=always)))
# (cd _build/default/test && ./test_hd.exe --color=always)
# Testing `hd'.
# This run has ID `06K4TXUA'.
# 
# > [FAIL]        header          0   header-000.
#   [FAIL]        header          1   header-000.
# 
# ┌──────────────────────────────────────────────────────────────────────────────┐
# │ [FAIL]        header          0   header-000.                                │
# └──────────────────────────────────────────────────────────────────────────────┘
# ASSERT Hd.decode: char '\r'
# FAIL Hd.decode: char '\r'
# Raised at Alcotest_engine__Test.check_err in file "src/alcotest-engine/test.ml", line 157, characters 20-48
# Called from Dune__exe__Test_hd.test_000.(fun) in file "test/test_hd.ml", line 68, characters 15-29
# Called from Alcotest_engine__Core.Make.protect_test.(fun) in file "src/alcotest-engine/core.ml", line 181, characters 17-23
# Called from Alcotest_engine__Monad.Identity.catch in file "src/alcotest-engine/monad.ml", line 24, characters 31-35
# 
# Logs saved to `~/.opam/5.2/.opam-switch/build/mrmime.0.6.0/_build/default/test/_build/_tests/hd/header.000.output'.
#  ──────────────────────────────────────────────────────────────────────────────
# 
# Full test results in `~/.opam/5.2/.opam-switch/build/mrmime.0.6.0/_build/default/test/_build/_tests/hd'.
# 2 failures! in 0.000s. 2 tests run.
```