### PR TITLE
Support Encoded-Word for field values.

### DIFF
--- a/corpus/utils.ml
+++ b/corpus/utils.ml
@@ -174,5 +174,6 @@ let field_to_string : type a. a Field.t -> string = function
   | Addresses -> "addresses"
   | MessageID -> "messageId"
   | Unstructured -> "unstructured"
+  | Unstructured_with_encoded -> "unstructured_with_encoded"
   | Content -> "content"
   | Encoding -> "encoding"

--- a/fuzz/dune
+++ b/fuzz/dune
@@ -28,6 +28,11 @@
  (modules fuzz_date)
  (libraries ptime.clock.os mrmime common crowbar))
 
+(executable
+ (name fuzz_unstructured_with_encoded)
+ (modules fuzz_unstructured_with_encoded)
+ (libraries mrmime common crowbar))
+
 ; (alias
 ;  (name runtest)
 ;  (deps (:fuzz_encoder fuzz_encoder.exe))

--- a/fuzz/fuzz_unstructured_with_encoded.ml
+++ b/fuzz/fuzz_unstructured_with_encoded.ml
@@ -1,0 +1,47 @@
+open Crowbar
+open Mrmime
+
+let space = map [ range ~min:1 4 ] Unstructured_with_encoded.Craft.sp
+
+let ascii_word =
+  map
+    [ dynamic_bind (range 78) Common.(string_from_alphabet atext) ]
+    Unstructured_with_encoded.Craft.v
+
+let encoded_word =
+  map [ bool; list1 uchar ] @@ fun base64 input ->
+  let input =
+    let buf = Buffer.create (2 * List.length input) in
+    List.iter (Uutf.Buffer.add_utf_8 buf) input;
+    Buffer.contents buf
+  in
+  match base64 with
+  | true ->
+      Unstructured_with_encoded.Craft.e ~encoding:Mrmime.Encoded_word.b input
+  | false ->
+      Unstructured_with_encoded.Craft.e ~encoding:Mrmime.Encoded_word.q input
+
+let unstructured_with_encoded =
+  map [ list (choose [ ascii_word; encoded_word; space ]) ] @@ fun data ->
+  Unstructured_with_encoded.Craft.compile data
+
+let () =
+  add_test ~name:"unstructured_with_encoded" [ unstructured_with_encoded ]
+  @@ fun input ->
+  let encoder = Unstructured_with_encoded.Encoder.unstructured_with_encoded in
+  let input_str = Prettym.to_string ~new_line:"\r\n " encoder input in
+  let reparsed =
+    let decoder =
+      Unstructured_with_encoded.Decoder.unstructured_with_encoded ()
+    in
+    Angstrom.parse_string ~consume:All decoder (input_str ^ "\r\n")
+    |> Result.fold ~ok:Fun.id ~error:(Crowbar.failf "parse failed: %s")
+  in
+  let reparsed_str =
+    Prettym.to_string ~margin:max_int ~new_line:"\r\n" encoder reparsed
+  in
+  (* Restort to comparing the rendered output, since we don't have equality or
+   * fully normalized representation. *)
+  check_eq
+    ~pp:Format.(fun ppf -> fprintf ppf "%S")
+    ~eq:String.equal input_str reparsed_str

--- a/lib/encoded_word.ml
+++ b/lib/encoded_word.ml
@@ -433,17 +433,7 @@ module Encoder = struct
     | Quoted_printable -> char ppf 'Q'
 
   let charset = using (Format.asprintf "%a" pp_charset) string
-
-  let to_quoted_printable input =
-    let buffer = Stdlib.Buffer.create (String.length input) in
-    let encoder = Pecu.Inline.encoder (`Buffer buffer) in
-    String.iter
-      (fun chr -> ignore @@ Pecu.Inline.encode encoder (`Char chr))
-      input;
-    ignore @@ Pecu.Inline.encode encoder `End;
-    Stdlib.Buffer.contents buffer
-
-  let quoted_printable = using to_quoted_printable string
+  let quoted_printable = using Quoted_printable.encode string
   let base64 = using (fun x -> Base64.encode_exn ~pad:true x) string
   let is_base64 = function Base64 -> true | _ -> false
 

--- a/lib/field.ml
+++ b/lib/field.ml
@@ -5,6 +5,7 @@ type 'a t =
   | Addresses : Address.t list t
   | MessageID : MessageID.t t
   | Unstructured : Unstructured.t t
+  | Unstructured_with_encoded : Unstructured_with_encoded.t t
   | Content : Content_type.t t
   | Encoding : Content_encoding.t t
 
@@ -36,6 +37,7 @@ let pp ppf (Field (field_name, w, v)) =
     | Addresses -> pp_list Address.pp
     | MessageID -> MessageID.pp
     | Unstructured -> Unstructured.pp
+    | Unstructured_with_encoded -> Unstructured_with_encoded.pp
     | Content -> Content_type.pp
     | Encoding -> Content_encoding.pp
   in
@@ -68,6 +70,10 @@ let parser : type a. a t -> a Angstrom.t = function
       let open Angstrom in
       Unstructured.Decoder.unstructured () >>= fun v ->
       return (v :> Unstructured.t)
+  | Unstructured_with_encoded ->
+      let open Angstrom in
+      Unstructured_with_encoded.Decoder.unstructured_with_encoded ()
+      >>= fun v -> return (v :> Unstructured_with_encoded.t)
   | Content -> Content_type.Decoder.content
   | Encoding -> Content_encoding.Decoder.mechanism
 
@@ -78,6 +84,8 @@ let encoder : type a. a t -> a Prettym.t = function
   | Addresses -> Address.Encoder.addresses
   | MessageID -> MessageID.Encoder.message_id
   | Unstructured -> Unstructured.Encoder.unstructured
+  | Unstructured_with_encoded ->
+      Unstructured_with_encoded.Encoder.unstructured_with_encoded
   | Content -> Content_type.Encoder.content_type
   | Encoding -> Content_encoding.Encoder.mechanism
 

--- a/lib/field.mli
+++ b/lib/field.mli
@@ -21,6 +21,7 @@ type 'a t =
   | Addresses : Address.t list t
   | MessageID : MessageID.t t
   | Unstructured : Unstructured.t t
+  | Unstructured_with_encoded : Unstructured_with_encoded.t t
   | Content : Content_type.t t
   | Encoding : Content_encoding.t t
       (** Type of kind of values according RFC2045/RFC5322. *)

--- a/lib/mrmime.ml
+++ b/lib/mrmime.ml
@@ -28,6 +28,7 @@ module Header = Header
 module Address = Address
 module Group = Group
 module Unstructured = Unstructured
+module Unstructured_with_encoded = Unstructured_with_encoded
 module Mail = Mail
 module Hd = Hd
 module Mt = Mt

--- a/lib/quoted_printable.ml
+++ b/lib/quoted_printable.ml
@@ -134,3 +134,12 @@ let to_end_of_input ~write_data ~write_line =
   peek_char *> available >>= take >>= fun str ->
   Pecu.src dec (Bytes.unsafe_of_string str) 0 (String.length str);
   parser ~write_data ~write_line dec
+
+let encode input =
+  let buffer = Stdlib.Buffer.create (String.length input) in
+  let encoder = Pecu.Inline.encoder (`Buffer buffer) in
+  String.iter
+    (fun chr -> ignore @@ Pecu.Inline.encode encoder (`Char chr))
+    input;
+  ignore @@ Pecu.Inline.encode encoder `End;
+  Stdlib.Buffer.contents buffer

--- a/lib/unstructured_with_encoded.ml
+++ b/lib/unstructured_with_encoded.ml
@@ -1,0 +1,101 @@
+type elt = [ Unstructured.elt | `Encoded of string * Emile.raw ]
+type t = elt list
+
+let pp_elt ppf : elt -> unit = function
+  | #Unstrctrd.elt as elt ->
+      Format.pp_print_string ppf
+        (Unstrctrd.to_utf_8_string (Unstrctrd.of_list [ elt ] |> Result.get_ok))
+  | `Open _ | `Close -> ()
+  | `Encoded encoded -> Emile.pp_phrase ppf [ `Encoded encoded ]
+
+let pp ppf u =
+  Format.pp_print_string ppf "<unstructured_with_encoded ";
+  List.iter (pp_elt ppf) u;
+  Format.pp_print_char ppf '>'
+
+module Decoder = struct
+  let post_process : Unstrctrd.t -> t =
+    let is_equals_sign u = Uchar.to_int u = 0x3d in
+    let is_question_mark u = Uchar.to_int u = 0x3f in
+    let rec encoded buf part = function
+      | `Uchar ch0 :: `Uchar ch1 :: rest
+        when part = 2 && is_question_mark ch0 && is_equals_sign ch1 -> (
+          Buffer.add_string buf "?=";
+          match Encoded_word.of_string (Buffer.contents buf) with
+          | Ok ew ->
+              let charset =
+                Encoded_word.charset_to_string ew.Encoded_word.charset
+              in
+              let data =
+                match ew.Encoded_word.encoding with
+                | Base64 -> Emile.Base64 ew.Encoded_word.data
+                | Quoted_printable ->
+                    Emile.Quoted_printable ew.Encoded_word.data
+              in
+              Ok (`Encoded (charset, data), rest)
+          | Error (`Msg _) -> Error ())
+      | `Uchar ch :: rest ->
+          let part = if is_question_mark ch then part + 1 else part in
+          Uutf.Buffer.add_utf_8 buf ch;
+          encoded buf part rest
+      | _ -> Error ()
+    in
+    let rec main (acc : t) = function
+      | `Uchar ch0 :: `Uchar ch1 :: rest
+        when is_equals_sign ch0 && is_question_mark ch1 -> (
+          let buf = Buffer.create 16 in
+          Buffer.add_string buf "=?";
+          match encoded buf 0 rest with
+          | Ok (elt, rest') -> main (elt :: acc) rest'
+          | Error () -> main (`Uchar ch1 :: `Uchar ch0 :: acc) rest)
+      | elt :: rest -> main (elt :: acc) rest
+      | [] -> List.rev acc
+    in
+    fun input -> main [] (input :> t)
+
+  let unstructured_with_encoded () =
+    let open Angstrom in
+    Unstructured.Decoder.unstructured () >>| post_process
+end
+
+module Craft = struct
+  let b = Encoded_word.b
+  let q = Encoded_word.q
+  let sp len = (Unstructured.Craft.sp len :> elt list)
+  let v s = (Unstructured.Craft.v s :> elt list)
+
+  let e ~encoding s =
+    let ew = Encoded_word.make_exn ~encoding s in
+    let charset = Encoded_word.charset_to_string ew.Encoded_word.charset in
+    match ew.Encoded_word.encoding with
+    | Base64 -> [ `Encoded (charset, Emile.Base64 ew.Encoded_word.data) ]
+    | Quoted_printable ->
+        [ `Encoded (charset, Emile.Quoted_printable ew.Encoded_word.data) ]
+
+  let compile : elt list list -> t = List.concat
+  let concat : t -> t -> t = List.append
+  let ( @ ) = concat
+end
+
+module Encoder = struct
+  open Prettym
+
+  let element : elt t =
+   fun ppf -> function
+    | `Encoded (charset, Emile.Quoted_printable data) ->
+        Encoded_word.Encoder.encoded_word ppf
+          { Encoded_word.charset = `Charset charset;
+            encoding = Encoded_word.Quoted_printable;
+            data
+          }
+    | `Encoded (charset, Emile.Base64 data) ->
+        Encoded_word.Encoder.encoded_word ppf
+          { Encoded_word.charset = `Charset charset;
+            encoding = Encoded_word.Base64;
+            data
+          }
+    | #Unstructured.elt as elt -> Unstructured.Encoder.element ppf elt
+
+  let unstructured_with_encoded : elt list t =
+   fun ppf lst -> list ~sep:Unstructured.Encoder.noop element ppf lst
+end

--- a/lib/unstructured_with_encoded.mli
+++ b/lib/unstructured_with_encoded.mli
@@ -1,0 +1,76 @@
+(*
+ * Copyright (c) 2025 Romain Calascibetta <romain.calascibetta@gmail.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+(** This module provides an alternative to {!Unstructured} which handles encoded
+    words.  It is meant for the Subject and other unstructured header fields,
+    where RFC-2047 adds additional semantics on top of the SMTP protocol.  The
+    addition of encoded words allows sending UTF-8 content in a 7 bit protocol,
+    like SMTP without the SMTPUTF8 extension.
+
+    When decoding, it is necessary to pass the following witness
+    {[
+      let witness =
+	Field_name.Map.singleton Field_name.subject
+	  Field.(Witness Unstructured_with_encoded)
+    ]}
+ *)
+
+type elt = [ Unstructured.elt | `Encoded of string * Emile.raw ]
+
+type t = elt list
+
+val pp_elt : Format.formatter -> elt -> unit
+(** Pretty printer of {!elt} mostly useful for debugging. *)
+
+val pp : Format.formatter -> t -> unit
+(** Pretty printer of {!t} mostly useful for debugging. *)
+
+module Decoder : sig
+  val unstructured_with_encoded : unit -> t Angstrom.t
+  (** [unstructured_with_encoded ()] creates a single-use Angstrom parser for
+      unstructured content with the encoded words. *)
+end
+
+module Encoder : sig
+  val unstructured_with_encoded : t Prettym.t
+  (** Encodes {!t} as unstructured text with encoded words.  The result is 7
+      bits if all non-ASCII characters occur within encoded words. *)
+end
+
+module Craft : sig
+  val b : Encoded_word.encoding
+  val q : Encoded_word.encoding
+  (** [q] and [p] are the two possible encodings for {!e}, imported here for
+      convenience. *)
+
+  val sp : int -> elt list
+  (** [sp n] adds [n] spaces which may be wrapped. *)
+
+  val v : string -> elt list
+  (** [v text] will produce [text] literally. *)
+
+  val e : encoding: Encoded_word.encoding -> string -> elt list
+  (** [e ~encoding text] will produce [text] encoded as [encoding]. *)
+
+  val compile : elt list list -> t
+  (** Assemble a list of the above into a complete field content. *)
+
+  val concat : elt list -> elt list -> elt list
+  (** List concatenation, specialized for our purpose. *)
+
+  val (@) : elt list -> elt list -> elt list
+  (** This is an alias for {!concat}. *)
+end

--- a/lib/unstructured_with_encoded.mli
+++ b/lib/unstructured_with_encoded.mli
@@ -15,21 +15,19 @@
  *)
 
 (** This module provides an alternative to {!Unstructured} which handles encoded
-    words.  It is meant for the Subject and other unstructured header fields,
-    where RFC-2047 adds additional semantics on top of the SMTP protocol.  The
+    words. It is meant for the Subject and other unstructured header fields,
+    where RFC-2047 adds additional semantics on top of the SMTP protocol. The
     addition of encoded words allows sending UTF-8 content in a 7 bit protocol,
     like SMTP without the SMTPUTF8 extension.
 
     When decoding, it is necessary to pass the following witness
     {[
       let witness =
-	Field_name.Map.singleton Field_name.subject
-	  Field.(Witness Unstructured_with_encoded)
-    ]}
- *)
+        Field_name.Map.singleton Field_name.subject
+          Field.(Witness Unstructured_with_encoded)
+    ]} *)
 
 type elt = [ Unstructured.elt | `Encoded of string * Emile.raw ]
-
 type t = elt list
 
 val pp_elt : Format.formatter -> elt -> unit
@@ -46,15 +44,13 @@ end
 
 module Encoder : sig
   val unstructured_with_encoded : t Prettym.t
-  (** Encodes {!t} as unstructured text with encoded words.  The result is 7
-      bits if all non-ASCII characters occur within encoded words. *)
+  (** Encodes {!t} as unstructured text with encoded words. The result is 7 bits
+      if all non-ASCII characters occur within encoded words. *)
 end
 
 module Craft : sig
   val b : Encoded_word.encoding
   val q : Encoded_word.encoding
-  (** [q] and [p] are the two possible encodings for {!e}, imported here for
-      convenience. *)
 
   val sp : int -> elt list
   (** [sp n] adds [n] spaces which may be wrapped. *)
@@ -62,7 +58,7 @@ module Craft : sig
   val v : string -> elt list
   (** [v text] will produce [text] literally. *)
 
-  val e : encoding: Encoded_word.encoding -> string -> elt list
+  val e : encoding:Encoded_word.encoding -> string -> elt list
   (** [e ~encoding text] will produce [text] encoded as [encoding]. *)
 
   val compile : elt list list -> t
@@ -71,6 +67,6 @@ module Craft : sig
   val concat : elt list -> elt list -> elt list
   (** List concatenation, specialized for our purpose. *)
 
-  val (@) : elt list -> elt list -> elt list
+  val ( @ ) : elt list -> elt list -> elt list
   (** This is an alias for {!concat}. *)
 end


### PR DESCRIPTION
Currently the examples uses unstructured for "Subject" fields, meaning that if it contains non-ASCII characters, the email can only be sent to an SMTP server which supports the SMTPUTF8 extension, which I don't think is universally available yet.  This is my proposal for a simple fix which makes Encoded-Word usable for encoding fields (other than as part of addresses), but leaves the decision of using it up to the developer.

I'm marking this a draft for now, since I'll be testing it locally but would like know as soon as possible if the proposal is a no-go.